### PR TITLE
fix: detect_image_cuda_tensors_to_cpu_missing

### DIFF
--- a/yoeo/detect.py
+++ b/yoeo/detect.py
@@ -101,7 +101,7 @@ def detect_image(model, image, img_size=416, conf_thres=0.5, nms_thres=0.5):
         detections, segmentations = model(input_img)
         detections = non_max_suppression(detections, conf_thres, nms_thres)
         detections = rescale_boxes(detections[0], img_size, image.shape[:2])
-    return detections.cpu().detach().numpy(), segmentations.cpu().detach().numpy()
+    return detections.numpy(), segmentations.cpu().detach().numpy()
 
 
 def detect(model, dataloader, output_path, img_size, conf_thres, nms_thres):

--- a/yoeo/detect.py
+++ b/yoeo/detect.py
@@ -101,7 +101,7 @@ def detect_image(model, image, img_size=416, conf_thres=0.5, nms_thres=0.5):
         detections, segmentations = model(input_img)
         detections = non_max_suppression(detections, conf_thres, nms_thres)
         detections = rescale_boxes(detections[0], img_size, image.shape[:2])
-    return detections.numpy(), segmentations.numpy()
+    return detections.cpu().detach().numpy(), segmentations.cpu().detach().numpy()
 
 
 def detect(model, dataloader, output_path, img_size, conf_thres, nms_thres):


### PR DESCRIPTION
fix: in detect_image from detect.py, cuda tensors were not moved back to the cpu. Therefore, conversion to numpy array was not possible.
